### PR TITLE
fix: make asteroids pass through the ship when ship is immune

### DIFF
--- a/main.py
+++ b/main.py
@@ -219,7 +219,8 @@ def game():
                 player.shield_power()
 
         # check mob player collision
-        hits = pygame.sprite.spritecollide(player, mobs, not player.just_started,
+        hits = pygame.sprite.spritecollide(player, mobs,
+                                           not player.just_started,
                                            pygame.sprite.collide_circle)
         for hit in hits:
             if not player.shield_up and not player.just_started:

--- a/main.py
+++ b/main.py
@@ -219,7 +219,7 @@ def game():
                 player.shield_power()
 
         # check mob player collision
-        hits = pygame.sprite.spritecollide(player, mobs, True,
+        hits = pygame.sprite.spritecollide(player, mobs, not player.just_started,
                                            pygame.sprite.collide_circle)
         for hit in hits:
             if not player.shield_up and not player.just_started:


### PR DESCRIPTION
This PR fixes #44.

I just changed the default `True` argument to `not player.just_started` so that asteroids pass through the ship if the ship just spawned. If `just_started` is false, it will remove the asteroids as normal. 